### PR TITLE
Replaces deprecated 'projection' keyword in FigureBase.gca() 

### DIFF
--- a/pymnet/visuals/drawbackends/mpl.py
+++ b/pymnet/visuals/drawbackends/mpl.py
@@ -48,7 +48,7 @@ class NetFigureMPL(drawnet.NetFigure):
 
         if ax == None:
             self.fig=plt.figure(figsize=self.figsize)
-            self.ax=self.fig.gca(projection='3d')
+            self.ax=self.fig.add_subplot(projection='3d')
         else:
             assert isinstance(ax,Axes3D), "The axes need to have 3D projection. Use, for example, fig.add_subplot(111, projection='3d')"
             self.ax = ax


### PR DESCRIPTION
Fixes https://github.com/bolozna/Multilayer-networks-library/issues/13